### PR TITLE
ParticleLib is now on Maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>xyz.xenondevs</groupId>
             <artifactId>particle</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
 
         <!-- Test Libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,9 @@
 
         <!-- Plugin Dependencies -->
         <dependency>
-            <groupId>xyz.xenondevs.particle</groupId>
-            <artifactId>particlelib</artifactId>
-            <version>1.3</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/ParticleLib-Plugin.jar</systemPath>
+            <groupId>xyz.xenondevs</groupId>
+            <artifactId>particle</artifactId>
+            <version>1.4</version>
         </dependency>
 
         <!-- Test Libraries -->


### PR DESCRIPTION
ParticleLib has been added to maven central so the system dependency can be replaced.